### PR TITLE
fix create_sandbox call

### DIFF
--- a/src/dirac_cwl_proto/job/submission_clients.py
+++ b/src/dirac_cwl_proto/job/submission_clients.py
@@ -130,10 +130,10 @@ class DIRACSubmissionClient(SubmissionClient):
             console.print(
                 "\t\t[blue]:information_source:[/blue] [bold]CLI:[/bold] Converting job model to jdl..."
             )
-            sandbox_id = await create_sandbox(job_submission_path)
+            sandbox_id = await create_sandbox([job_submission_path])
             job_submission_path.unlink()
 
-            jdl = self.convert_to_jdl(job, [sandbox_id])
+            jdl = self.convert_to_jdl(job, sandbox_id)
             jdls.append(jdl)
 
         console.print(
@@ -149,7 +149,7 @@ class DIRACSubmissionClient(SubmissionClient):
         )
         return True
 
-    def convert_to_jdl(self, job: JobSubmissionModel, sandbox_ids: list[str]) -> str:
+    def convert_to_jdl(self, job: JobSubmissionModel, sandbox_id: str) -> str:
         """
         Convert job model to jdl.
 
@@ -175,6 +175,6 @@ class DIRACSubmissionClient(SubmissionClient):
         if job.scheduling.sites:
             jdl_lines.append(f"Site = {job.scheduling.sites};")
 
-        jdl_lines.append(f"InputSandbox = {sandbox_ids};")
+        jdl_lines.append(f"InputSandbox = {sandbox_id};")
 
         return "\n".join(jdl_lines)


### PR DESCRIPTION
Testing in the CTAO deployment showed up 2 issues:

- create_sandbox expects list[Path]
- jdl syntax was wrong as the InputSandbox field should not be a list

I think that there are other issues with the content of the ISB, but I will adress this in a other PR.